### PR TITLE
Bump go to 1.16, also support 1.15

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.15', '1.14']
+        go: ['1.16', '1.15']
     env:
       GO_VER: ${{ matrix.go }}
     steps:
@@ -51,14 +51,14 @@ jobs:
           GOTOOLDIR: /usr/local/go/pkg/tool/linux_amd64
         with:
           args: ./...
-        if: env.GO_VER == '1.15'
+        if: env.GO_VER == '1.16'
 
   build-macos:
     name: MacOS build
     runs-on: macos-latest
     strategy:
       matrix:
-        go: ['1.15', '1.14']
+        go: ['1.16', '1.15']
     steps:
 
       - name: Set up Go ${{ matrix.go }}
@@ -90,7 +90,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        go: ['1.15', '1.14']
+        go: ['1.16', '1.15']
     steps:
 
       - name: Set up Go ${{ matrix.go }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,10 @@ jobs:
     name: Linux release
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.15
+      - name: Set up Go 1.16
         uses: actions/setup-go@v2
         with:
-          go-version: "1.15"
+          go-version: "1.16"
         id: go
 
       - name: Check out code
@@ -55,10 +55,10 @@ jobs:
     name: MacOS release
     runs-on: macos-latest
     steps:
-      - name: Set up Go 1.15
+      - name: Set up Go 1.16
         uses: actions/setup-go@v2
         with:
-          go-version: "1.15"
+          go-version: "1.16"
         id: go
 
       - name: Check out code
@@ -96,10 +96,10 @@ jobs:
     name: Windows release
     runs-on: windows-latest
     steps:
-      - name: Set up Go 1.15
+      - name: Set up Go 1.16
         uses: actions/setup-go@v2
         with:
-          go-version: "1.15"
+          go-version: "1.16"
         id: go
 
       - name: Check out code

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module code.vegaprotocol.io/liqbot
 
-go 1.14
+go 1.16
 
 require (
 	code.vegaprotocol.io/go-wallet v0.6.2


### PR DESCRIPTION
This PR adds golang v1.16, retains v1.15, and ditches v1.14.