### PR TITLE
Add auction support

### DIFF
--- a/bot/normal/datarequests.go
+++ b/bot/normal/datarequests.go
@@ -34,10 +34,16 @@ func (b *Bot) lookupInitialValues() error {
 	if err != nil {
 		return err
 	}
-	if len(positions) != 1 {
-		return errors.New("One position item required")
+
+	// If we have not traded yet then we won't have a position
+	if positions == nil {
+		b.openVolume = 0
+	} else {
+		if len(positions) != 1 {
+			return errors.New("One position item required")
+		}
+		b.openVolume = positions[0].OpenVolume
 	}
-	b.openVolume = positions[0].OpenVolume
 	return nil
 }
 
@@ -126,5 +132,6 @@ func (b *Bot) getMarketData() error {
 		return errors.Wrap(err, "Failed to get market data by id")
 	}
 	b.marketData = response.MarketData
+	b.currentPrice = response.MarketData.StaticMidPrice
 	return nil
 }

--- a/bot/normal/helpers.go
+++ b/bot/normal/helpers.go
@@ -27,6 +27,13 @@ func max(a, b uint64) uint64 {
 	return b
 }
 
+func min(a, b uint64) uint64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
 func abs(a int64) int64 {
 	if a < 0 {
 		return -a

--- a/bot/normal/normal.go
+++ b/bot/normal/normal.go
@@ -323,10 +323,16 @@ func (b *Bot) checkPositionManagement() {
 
 	if shouldBuy {
 		size := uint64(float64(abs(b.openVolume)) * b.strategy.PosManagementFraction)
-		b.sendOrder(size, 0, proto.Side_SIDE_BUY, proto.Order_TIME_IN_FORCE_IOC, proto.Order_TYPE_MARKET, "PosManagement", 0)
+		err := b.sendOrder(size, 0, proto.Side_SIDE_BUY, proto.Order_TIME_IN_FORCE_IOC, proto.Order_TYPE_MARKET, "PosManagement", 0)
+		if err != nil {
+			log.Warningln("Failed to place a position management buy")
+		}
 	} else if shouldSell {
 		size := uint64(float64(abs(b.openVolume)) * b.strategy.PosManagementFraction)
-		b.sendOrder(size, 0, proto.Side_SIDE_SELL, proto.Order_TIME_IN_FORCE_IOC, proto.Order_TYPE_MARKET, "PosManagement", 0)
+		err := b.sendOrder(size, 0, proto.Side_SIDE_SELL, proto.Order_TIME_IN_FORCE_IOC, proto.Order_TYPE_MARKET, "PosManagement", 0)
+		if err != nil {
+			log.Warningln("Failed to place a position management sell")
+		}
 	}
 }
 
@@ -433,7 +439,7 @@ func (b *Bot) placeAuctionOrders() {
 
 	// Place the random orders split into
 	var totalVolume uint64
-	r := rand.New(rand.NewSource(1))
+	r := rand.New(rand.NewSource(1)) // #nosec G404 This suboptimal rand generator is fine for now
 
 	for totalVolume < b.config.StrategyDetails.AuctionVolume {
 		remaining := b.config.StrategyDetails.AuctionVolume - totalVolume


### PR DESCRIPTION
Prevent the liquidity provision from being updated during an auction.
Also stop any position management during an auction.

Place some orders up to the volume specified in `AuctionVolume` when we first enter an auction in randomly priced values around the current price to try to assist in getting out of a price/liquidity auction.

Closes #7 