### PR TITLE
Check connection state before sending gRPC request

### DIFF
--- a/bot/normal/normal.go
+++ b/bot/normal/normal.go
@@ -489,9 +489,9 @@ func (b *Bot) placeAuctionOrders() {
 	for totalVolume < b.config.StrategyDetails.AuctionVolume {
 		remaining := b.config.StrategyDetails.AuctionVolume - totalVolume
 		size := min(1+(b.config.StrategyDetails.AuctionVolume/10), remaining)
-		price := b.currentPrice + (uint64(rand.Int63n(100) - 50))
+		price := b.currentPrice + (uint64(rand.Int63n(100) - 50)) // #nosec G404 This suboptimal rand generator is fine for now
 		side := proto.Side_SIDE_BUY
-		if rand.Intn(2) == 0 {
+		if rand.Intn(2) == 0 { // #nosec G404 This suboptimal rand generator is fine for now
 			side = proto.Side_SIDE_SELL
 		}
 		err := b.sendOrder(size, price, side, proto.Order_TIME_IN_FORCE_GTT, proto.Order_TYPE_LIMIT, "AuctionOrder", 330)

--- a/bot/normal/normal.go
+++ b/bot/normal/normal.go
@@ -491,7 +491,7 @@ func (b *Bot) placeAuctionOrders() {
 		size := min(1+(b.config.StrategyDetails.AuctionVolume/10), remaining)
 		price := b.currentPrice + (uint64(rand.Int63n(100) - 50)) // #nosec G404 This suboptimal rand generator is fine for now
 		side := proto.Side_SIDE_BUY
-		if rand.Intn(2) == 0 { // #nosec G404 This suboptimal rand generator is fine for now
+		if rand.Intn(2) == 0 {
 			side = proto.Side_SIDE_SELL
 		}
 		err := b.sendOrder(size, price, side, proto.Order_TIME_IN_FORCE_GTT, proto.Order_TYPE_LIMIT, "AuctionOrder", 330)

--- a/bot/normal/normal.go
+++ b/bot/normal/normal.go
@@ -449,14 +449,14 @@ func (b *Bot) initialiseData() error {
 
 	err = b.lookupInitialValues()
 	if err != nil {
-		b.log.Debugf("Stopping position management as we could not get initial values: %w", err)
+		b.log.Debugf("Stopping position management as we could not get initial values: %v", err)
 		return err
 	}
 
 	if !b.eventStreamLive {
 		err = b.subscribeToEvents()
 		if err != nil {
-			b.log.Debugf("Unable to subscribe to event bus feeds: %w", err)
+			b.log.Debugf("Unable to subscribe to event bus feeds: %v", err)
 			return err
 		}
 	}
@@ -464,7 +464,7 @@ func (b *Bot) initialiseData() error {
 	if !b.positionStreamLive {
 		err = b.subscribePositions()
 		if err != nil {
-			b.log.Debugf("Unable to subscribe to event bus feeds: %w", err)
+			b.log.Debugf("Unable to subscribe to event bus feeds: %v", err)
 			return err
 		}
 	}
@@ -557,7 +557,7 @@ func (b *Bot) runPositionManagement() {
 			for !b.positionStreamLive || !b.eventStreamLive {
 				err = doze(time.Duration(sleepTime)*time.Millisecond, b.stopPosMgmt)
 				if err != nil {
-					b.log.Debugf("Stopping bot position management: %w", err)
+					b.log.Debugf("Stopping bot position management: %v", err)
 					b.active = false
 					return
 				}
@@ -570,7 +570,7 @@ func (b *Bot) runPositionManagement() {
 
 			err = doze(time.Duration(sleepTime)*time.Millisecond, b.stopPosMgmt)
 			if err != nil {
-				b.log.Debug("Stopping bot position management")
+				b.log.Debugf("Stopping bot position management: %v", err)
 				b.active = false
 				return
 			}

--- a/bot/normal/normal.go
+++ b/bot/normal/normal.go
@@ -486,10 +486,11 @@ func (b *Bot) placeAuctionOrders() {
 	// Place the random orders split into
 	var totalVolume uint64
 	rand.Seed(time.Now().UnixNano())
+	/* #nosec G404 */
 	for totalVolume < b.config.StrategyDetails.AuctionVolume {
 		remaining := b.config.StrategyDetails.AuctionVolume - totalVolume
 		size := min(1+(b.config.StrategyDetails.AuctionVolume/10), remaining)
-		price := b.currentPrice + (uint64(rand.Int63n(100) - 50)) // #nosec G404 This suboptimal rand generator is fine for now
+		price := b.currentPrice + (uint64(rand.Int63n(100) - 50))
 		side := proto.Side_SIDE_BUY
 		if rand.Intn(2) == 0 {
 			side = proto.Side_SIDE_SELL

--- a/bot/normal/normal.go
+++ b/bot/normal/normal.go
@@ -449,14 +449,16 @@ func (b *Bot) initialiseData() error {
 
 	err = b.lookupInitialValues()
 	if err != nil {
-		b.log.Debugf("Stopping position management as we could not get initial values: %v", err)
+		b.log.WithFields(log.Fields{"error": err.Error()}).
+			Debug("Stopping position management as we could not get initial values")
 		return err
 	}
 
 	if !b.eventStreamLive {
 		err = b.subscribeToEvents()
 		if err != nil {
-			b.log.Debugf("Unable to subscribe to event bus feeds: %v", err)
+			b.log.WithFields(log.Fields{"error": err.Error()}).
+				Debug("Unable to subscribe to event bus feeds")
 			return err
 		}
 	}
@@ -464,7 +466,8 @@ func (b *Bot) initialiseData() error {
 	if !b.positionStreamLive {
 		err = b.subscribePositions()
 		if err != nil {
-			b.log.Debugf("Unable to subscribe to event bus feeds: %v", err)
+			b.log.WithFields(log.Fields{"error": err.Error()}).
+				Debug("Unable to subscribe to event bus feeds")
 			return err
 		}
 	}
@@ -558,7 +561,8 @@ func (b *Bot) runPositionManagement() {
 			for !b.positionStreamLive || !b.eventStreamLive {
 				err = doze(time.Duration(sleepTime)*time.Millisecond, b.stopPosMgmt)
 				if err != nil {
-					b.log.Debugf("Stopping bot position management: %v", err)
+					b.log.WithFields(log.Fields{"error": err.Error()}).
+						Debug("Stopping bot position management")
 					b.active = false
 					return
 				}
@@ -571,7 +575,8 @@ func (b *Bot) runPositionManagement() {
 
 			err = doze(time.Duration(sleepTime)*time.Millisecond, b.stopPosMgmt)
 			if err != nil {
-				b.log.Debugf("Stopping bot position management: %v", err)
+				b.log.WithFields(log.Fields{"error": err.Error()}).
+					Debug("Stopping bot position management")
 				b.active = false
 				return
 			}
@@ -665,7 +670,8 @@ func (b *Bot) runPriceSteering() {
 
 	base, quote, err := b.getPriceParts()
 	if err != nil {
-		b.log.Fatalf("Unable to build instrument for external price feed: %v", err)
+		b.log.WithFields(log.Fields{"error": err.Error()}).
+			Fatal("Unable to build instrument for external price feed")
 	}
 
 	ppcfg := ppconfig.PriceConfig{
@@ -716,7 +722,8 @@ func (b *Bot) runPriceSteering() {
 						price, size, priceError := b.GetRealisticOrderDetails(externalPrice)
 
 						if priceError != nil {
-							b.log.Fatalf("Unable to get realistic order details for price steering: %v\n", priceError)
+							b.log.WithFields(log.Fields{"error": priceError.Error()}).
+								Fatal("Unable to get realistic order details for price steering")
 						}
 
 						size = uint64(float64(size) * b.strategy.PriceSteerOrderScale)

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -8,4 +8,7 @@ var (
 
 	// ErrInterrupted indicates that a sleep was interrupted
 	ErrInterrupted = errors.New("interrupted")
+
+	// ErrConnectionNotReady indicated that the network connection to the gRPC server is not ready
+	ErrConnectionNotReady = errors.New("gRPC connection not ready")
 )

--- a/node/grpcnode.go
+++ b/node/grpcnode.go
@@ -11,6 +11,7 @@ import (
 	"github.com/vegaprotocol/api/grpc/clients/go/generated/code.vegaprotocol.io/vega/proto/api"
 	apigrpc "github.com/vegaprotocol/api/grpc/clients/go/grpc"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
 )
 
 // GRPCNode stores state for a Vega node.
@@ -52,7 +53,7 @@ func (n *GRPCNode) GetAddress() (url.URL, error) {
 // SubmitTransaction submits a signed transaction
 func (n *GRPCNode) SubmitTransaction(req *api.SubmitTransactionRequest) (response *api.SubmitTransactionResponse, err error) {
 	msg := "gRPC call failed: SubmitTransaction: %w"
-	if n == nil {
+	if n == nil || n.conn.GetState() != connectivity.Ready {
 		err = fmt.Errorf(msg, e.ErrNil)
 		return
 	}
@@ -73,7 +74,7 @@ func (n *GRPCNode) SubmitTransaction(req *api.SubmitTransactionRequest) (respons
 // GetVegaTime gets the latest block header time from the node.
 func (n *GRPCNode) GetVegaTime() (t time.Time, err error) {
 	msg := "gRPC call failed: GetVegaTime: %w"
-	if n == nil {
+	if n == nil || n.conn.GetState() != connectivity.Ready {
 		err = fmt.Errorf(msg, e.ErrNil)
 		return
 	}
@@ -99,7 +100,7 @@ func (n *GRPCNode) GetVegaTime() (t time.Time, err error) {
 // MarketByID gets a Market from the node
 func (n *GRPCNode) MarketByID(req *api.MarketByIDRequest) (response *api.MarketByIDResponse, err error) {
 	msg := "gRPC call failed: MarketByID: %w"
-	if n == nil {
+	if n == nil || n.conn.GetState() != connectivity.Ready {
 		err = fmt.Errorf(msg, e.ErrNil)
 		return
 	}
@@ -117,7 +118,7 @@ func (n *GRPCNode) MarketByID(req *api.MarketByIDRequest) (response *api.MarketB
 // MarketDataByID gets market data from the node
 func (n *GRPCNode) MarketDataByID(req *api.MarketDataByIDRequest) (response *api.MarketDataByIDResponse, err error) {
 	msg := "gRPC call failed: MarketDataByID: %w"
-	if n == nil {
+	if n == nil || n.conn.GetState() != connectivity.Ready {
 		err = fmt.Errorf(msg, e.ErrNil)
 		return
 	}
@@ -135,7 +136,7 @@ func (n *GRPCNode) MarketDataByID(req *api.MarketDataByIDRequest) (response *api
 // LiquidityProvisions gets the liquidity provisions for a given market and party.
 func (n *GRPCNode) LiquidityProvisions(req *api.LiquidityProvisionsRequest) (response *api.LiquidityProvisionsResponse, err error) {
 	msg := "gRPC call failed: LiquidityProvisions: %w"
-	if n == nil {
+	if n == nil || n.conn.GetState() != connectivity.Ready {
 		err = fmt.Errorf(msg, e.ErrNil)
 		return
 	}
@@ -153,7 +154,7 @@ func (n *GRPCNode) LiquidityProvisions(req *api.LiquidityProvisionsRequest) (res
 // MarketDepth gets the depth for a market.
 func (n *GRPCNode) MarketDepth(req *api.MarketDepthRequest) (response *api.MarketDepthResponse, err error) {
 	msg := "gRPC call failed: MarketDepth: %w"
-	if n == nil {
+	if n == nil || n.conn.GetState() != connectivity.Ready {
 		err = fmt.Errorf(msg, e.ErrNil)
 		return
 	}
@@ -171,7 +172,7 @@ func (n *GRPCNode) MarketDepth(req *api.MarketDepthRequest) (response *api.Marke
 // PartyAccounts gets Accounts for a given partyID from the node
 func (n *GRPCNode) PartyAccounts(req *api.PartyAccountsRequest) (response *api.PartyAccountsResponse, err error) {
 	msg := "gRPC call failed: PartyAccounts: %w"
-	if n == nil {
+	if n == nil || n.conn.GetState() != connectivity.Ready {
 		err = fmt.Errorf(msg, e.ErrNil)
 		return
 	}
@@ -189,7 +190,7 @@ func (n *GRPCNode) PartyAccounts(req *api.PartyAccountsRequest) (response *api.P
 // PositionsByParty gets the positions for a party.
 func (n *GRPCNode) PositionsByParty(req *api.PositionsByPartyRequest) (response *api.PositionsByPartyResponse, err error) {
 	msg := "gRPC call failed: PositionsByParty: %w"
-	if n == nil {
+	if n == nil || n.conn.GetState() != connectivity.Ready {
 		err = fmt.Errorf(msg, e.ErrNil)
 		return
 	}
@@ -207,7 +208,7 @@ func (n *GRPCNode) PositionsByParty(req *api.PositionsByPartyRequest) (response 
 // ObserveEventBus starts a network connection to the node to sending event messages on
 func (n *GRPCNode) ObserveEventBus() (stream api.TradingDataService_ObserveEventBusClient, err error) {
 	msg := "gRPC call failed: ObserveEventBus: %w"
-	if n == nil {
+	if n == nil || n.conn.GetState() != connectivity.Ready {
 		err = fmt.Errorf(msg, e.ErrNil)
 		return
 	}
@@ -223,7 +224,7 @@ func (n *GRPCNode) ObserveEventBus() (stream api.TradingDataService_ObserveEvent
 // PositionsSubscribe starts a network connection to receive the party position as it updates
 func (n *GRPCNode) PositionsSubscribe(req *api.PositionsSubscribeRequest) (stream api.TradingDataService_PositionsSubscribeClient, err error) {
 	msg := "gRPC call failed: PositionsSubscribe: %w"
-	if n == nil {
+	if n == nil || n.conn.GetState() != connectivity.Ready {
 		err = fmt.Errorf(msg, e.ErrNil)
 		return
 	}
@@ -239,7 +240,7 @@ func (n *GRPCNode) PositionsSubscribe(req *api.PositionsSubscribeRequest) (strea
 // AssetByID returns information about a given asset
 func (n *GRPCNode) AssetByID(assetID string) (response *api.AssetByIDResponse, err error) {
 	msg := "gRPC call failed: AssetByID: %w"
-	if n == nil {
+	if n == nil || n.conn.GetState() != connectivity.Ready {
 		err = fmt.Errorf(msg, e.ErrNil)
 		return
 	}
@@ -256,5 +257,4 @@ func (n *GRPCNode) AssetByID(assetID string) (response *api.AssetByIDResponse, e
 		err = fmt.Errorf(msg, apigrpc.ErrorDetail(err))
 	}
 	return
-
 }

--- a/node/grpcnode.go
+++ b/node/grpcnode.go
@@ -53,8 +53,13 @@ func (n *GRPCNode) GetAddress() (url.URL, error) {
 // SubmitTransaction submits a signed transaction
 func (n *GRPCNode) SubmitTransaction(req *api.SubmitTransactionRequest) (response *api.SubmitTransactionResponse, err error) {
 	msg := "gRPC call failed: SubmitTransaction: %w"
-	if n == nil || n.conn.GetState() != connectivity.Ready {
+	if n == nil {
 		err = fmt.Errorf(msg, e.ErrNil)
+		return
+	}
+
+	if n.conn.GetState() != connectivity.Ready {
+		err = fmt.Errorf(msg, e.ErrConnectionNotReady)
 		return
 	}
 
@@ -74,8 +79,13 @@ func (n *GRPCNode) SubmitTransaction(req *api.SubmitTransactionRequest) (respons
 // GetVegaTime gets the latest block header time from the node.
 func (n *GRPCNode) GetVegaTime() (t time.Time, err error) {
 	msg := "gRPC call failed: GetVegaTime: %w"
-	if n == nil || n.conn.GetState() != connectivity.Ready {
+	if n == nil {
 		err = fmt.Errorf(msg, e.ErrNil)
+		return
+	}
+
+	if n.conn.GetState() != connectivity.Ready {
+		err = fmt.Errorf(msg, e.ErrConnectionNotReady)
 		return
 	}
 
@@ -100,8 +110,13 @@ func (n *GRPCNode) GetVegaTime() (t time.Time, err error) {
 // MarketByID gets a Market from the node
 func (n *GRPCNode) MarketByID(req *api.MarketByIDRequest) (response *api.MarketByIDResponse, err error) {
 	msg := "gRPC call failed: MarketByID: %w"
-	if n == nil || n.conn.GetState() != connectivity.Ready {
+	if n == nil {
 		err = fmt.Errorf(msg, e.ErrNil)
+		return
+	}
+
+	if n.conn.GetState() != connectivity.Ready {
+		err = fmt.Errorf(msg, e.ErrConnectionNotReady)
 		return
 	}
 
@@ -118,8 +133,13 @@ func (n *GRPCNode) MarketByID(req *api.MarketByIDRequest) (response *api.MarketB
 // MarketDataByID gets market data from the node
 func (n *GRPCNode) MarketDataByID(req *api.MarketDataByIDRequest) (response *api.MarketDataByIDResponse, err error) {
 	msg := "gRPC call failed: MarketDataByID: %w"
-	if n == nil || n.conn.GetState() != connectivity.Ready {
+	if n == nil {
 		err = fmt.Errorf(msg, e.ErrNil)
+		return
+	}
+
+	if n.conn.GetState() != connectivity.Ready {
+		err = fmt.Errorf(msg, e.ErrConnectionNotReady)
 		return
 	}
 
@@ -136,8 +156,13 @@ func (n *GRPCNode) MarketDataByID(req *api.MarketDataByIDRequest) (response *api
 // LiquidityProvisions gets the liquidity provisions for a given market and party.
 func (n *GRPCNode) LiquidityProvisions(req *api.LiquidityProvisionsRequest) (response *api.LiquidityProvisionsResponse, err error) {
 	msg := "gRPC call failed: LiquidityProvisions: %w"
-	if n == nil || n.conn.GetState() != connectivity.Ready {
+	if n == nil {
 		err = fmt.Errorf(msg, e.ErrNil)
+		return
+	}
+
+	if n.conn.GetState() != connectivity.Ready {
+		err = fmt.Errorf(msg, e.ErrConnectionNotReady)
 		return
 	}
 
@@ -154,8 +179,13 @@ func (n *GRPCNode) LiquidityProvisions(req *api.LiquidityProvisionsRequest) (res
 // MarketDepth gets the depth for a market.
 func (n *GRPCNode) MarketDepth(req *api.MarketDepthRequest) (response *api.MarketDepthResponse, err error) {
 	msg := "gRPC call failed: MarketDepth: %w"
-	if n == nil || n.conn.GetState() != connectivity.Ready {
+	if n == nil {
 		err = fmt.Errorf(msg, e.ErrNil)
+		return
+	}
+
+	if n.conn.GetState() != connectivity.Ready {
+		err = fmt.Errorf(msg, e.ErrConnectionNotReady)
 		return
 	}
 
@@ -172,8 +202,13 @@ func (n *GRPCNode) MarketDepth(req *api.MarketDepthRequest) (response *api.Marke
 // PartyAccounts gets Accounts for a given partyID from the node
 func (n *GRPCNode) PartyAccounts(req *api.PartyAccountsRequest) (response *api.PartyAccountsResponse, err error) {
 	msg := "gRPC call failed: PartyAccounts: %w"
-	if n == nil || n.conn.GetState() != connectivity.Ready {
+	if n == nil {
 		err = fmt.Errorf(msg, e.ErrNil)
+		return
+	}
+
+	if n.conn.GetState() != connectivity.Ready {
+		err = fmt.Errorf(msg, e.ErrConnectionNotReady)
 		return
 	}
 
@@ -190,8 +225,13 @@ func (n *GRPCNode) PartyAccounts(req *api.PartyAccountsRequest) (response *api.P
 // PositionsByParty gets the positions for a party.
 func (n *GRPCNode) PositionsByParty(req *api.PositionsByPartyRequest) (response *api.PositionsByPartyResponse, err error) {
 	msg := "gRPC call failed: PositionsByParty: %w"
-	if n == nil || n.conn.GetState() != connectivity.Ready {
+	if n == nil {
 		err = fmt.Errorf(msg, e.ErrNil)
+		return
+	}
+
+	if n.conn.GetState() != connectivity.Ready {
+		err = fmt.Errorf(msg, e.ErrConnectionNotReady)
 		return
 	}
 
@@ -208,8 +248,13 @@ func (n *GRPCNode) PositionsByParty(req *api.PositionsByPartyRequest) (response 
 // ObserveEventBus starts a network connection to the node to sending event messages on
 func (n *GRPCNode) ObserveEventBus() (stream api.TradingDataService_ObserveEventBusClient, err error) {
 	msg := "gRPC call failed: ObserveEventBus: %w"
-	if n == nil || n.conn.GetState() != connectivity.Ready {
+	if n == nil {
 		err = fmt.Errorf(msg, e.ErrNil)
+		return
+	}
+
+	if n.conn.GetState() != connectivity.Ready {
+		err = fmt.Errorf(msg, e.ErrConnectionNotReady)
 		return
 	}
 
@@ -224,8 +269,13 @@ func (n *GRPCNode) ObserveEventBus() (stream api.TradingDataService_ObserveEvent
 // PositionsSubscribe starts a network connection to receive the party position as it updates
 func (n *GRPCNode) PositionsSubscribe(req *api.PositionsSubscribeRequest) (stream api.TradingDataService_PositionsSubscribeClient, err error) {
 	msg := "gRPC call failed: PositionsSubscribe: %w"
-	if n == nil || n.conn.GetState() != connectivity.Ready {
+	if n == nil {
 		err = fmt.Errorf(msg, e.ErrNil)
+		return
+	}
+
+	if n.conn.GetState() != connectivity.Ready {
+		err = fmt.Errorf(msg, e.ErrConnectionNotReady)
 		return
 	}
 
@@ -240,8 +290,13 @@ func (n *GRPCNode) PositionsSubscribe(req *api.PositionsSubscribeRequest) (strea
 // AssetByID returns information about a given asset
 func (n *GRPCNode) AssetByID(assetID string) (response *api.AssetByIDResponse, err error) {
 	msg := "gRPC call failed: AssetByID: %w"
-	if n == nil || n.conn.GetState() != connectivity.Ready {
+	if n == nil {
 		err = fmt.Errorf(msg, e.ErrNil)
+		return
+	}
+
+	if n.conn.GetState() != connectivity.Ready {
+		err = fmt.Errorf(msg, e.ErrConnectionNotReady)
 		return
 	}
 


### PR DESCRIPTION
We are seeing a problem where the gRPC calls are hanging for 15 or so minutes when trying to reconnect to a node. This might be due to us filling the send buffer with requests while the connection is down. I have added code to check if the connection is ready to send before we send any more requests. 