### PR TITLE
Look up market IDs from base+quote info (#64)

### DIFF
--- a/bot/mocks/bot_mock.go
+++ b/bot/mocks/bot_mock.go
@@ -33,6 +33,20 @@ func (m *MockBot) EXPECT() *MockBotMockRecorder {
 	return m.recorder
 }
 
+// GetTraderDetails mocks base method.
+func (m *MockBot) GetTraderDetails() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTraderDetails")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetTraderDetails indicates an expected call of GetTraderDetails.
+func (mr *MockBotMockRecorder) GetTraderDetails() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTraderDetails", reflect.TypeOf((*MockBot)(nil).GetTraderDetails))
+}
+
 // Start mocks base method.
 func (m *MockBot) Start() error {
 	m.ctrl.T.Helper()

--- a/bot/normal/mocks/node_mock.go
+++ b/bot/normal/mocks/node_mock.go
@@ -36,6 +36,21 @@ func (m *MockNode) EXPECT() *MockNodeMockRecorder {
 	return m.recorder
 }
 
+// AssetByID mocks base method.
+func (m *MockNode) AssetByID(arg0 string) (*api.AssetByIDResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AssetByID", arg0)
+	ret0, _ := ret[0].(*api.AssetByIDResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AssetByID indicates an expected call of AssetByID.
+func (mr *MockNodeMockRecorder) AssetByID(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssetByID", reflect.TypeOf((*MockNode)(nil).AssetByID), arg0)
+}
+
 // GetAddress mocks base method.
 func (m *MockNode) GetAddress() (url.URL, error) {
 	m.ctrl.T.Helper()
@@ -64,6 +79,21 @@ func (m *MockNode) GetVegaTime() (time.Time, error) {
 func (mr *MockNodeMockRecorder) GetVegaTime() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVegaTime", reflect.TypeOf((*MockNode)(nil).GetVegaTime))
+}
+
+// LastBlockHeight mocks base method.
+func (m *MockNode) LastBlockHeight(arg0 *api.LastBlockHeightRequest) (*api.LastBlockHeightResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LastBlockHeight", arg0)
+	ret0, _ := ret[0].(*api.LastBlockHeightResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LastBlockHeight indicates an expected call of LastBlockHeight.
+func (mr *MockNodeMockRecorder) LastBlockHeight(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LastBlockHeight", reflect.TypeOf((*MockNode)(nil).LastBlockHeight), arg0)
 }
 
 // LiquidityProvisions mocks base method.
@@ -111,6 +141,36 @@ func (mr *MockNodeMockRecorder) MarketDataByID(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarketDataByID", reflect.TypeOf((*MockNode)(nil).MarketDataByID), arg0)
 }
 
+// Markets mocks base method.
+func (m *MockNode) Markets(arg0 *api.MarketsRequest) (*api.MarketsResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Markets", arg0)
+	ret0, _ := ret[0].(*api.MarketsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Markets indicates an expected call of Markets.
+func (mr *MockNodeMockRecorder) Markets(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Markets", reflect.TypeOf((*MockNode)(nil).Markets), arg0)
+}
+
+// ObserveEventBus mocks base method.
+func (m *MockNode) ObserveEventBus() (api.TradingDataService_ObserveEventBusClient, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ObserveEventBus")
+	ret0, _ := ret[0].(api.TradingDataService_ObserveEventBusClient)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ObserveEventBus indicates an expected call of ObserveEventBus.
+func (mr *MockNodeMockRecorder) ObserveEventBus() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ObserveEventBus", reflect.TypeOf((*MockNode)(nil).ObserveEventBus))
+}
+
 // PartyAccounts mocks base method.
 func (m *MockNode) PartyAccounts(arg0 *api.PartyAccountsRequest) (*api.PartyAccountsResponse, error) {
 	m.ctrl.T.Helper()
@@ -139,6 +199,21 @@ func (m *MockNode) PositionsByParty(arg0 *api.PositionsByPartyRequest) (*api.Pos
 func (mr *MockNodeMockRecorder) PositionsByParty(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PositionsByParty", reflect.TypeOf((*MockNode)(nil).PositionsByParty), arg0)
+}
+
+// PositionsSubscribe mocks base method.
+func (m *MockNode) PositionsSubscribe(arg0 *api.PositionsSubscribeRequest) (api.TradingDataService_PositionsSubscribeClient, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PositionsSubscribe", arg0)
+	ret0, _ := ret[0].(api.TradingDataService_PositionsSubscribeClient)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PositionsSubscribe indicates an expected call of PositionsSubscribe.
+func (mr *MockNodeMockRecorder) PositionsSubscribe(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PositionsSubscribe", reflect.TypeOf((*MockNode)(nil).PositionsSubscribe), arg0)
 }
 
 // SubmitTransaction mocks base method.

--- a/bot/normal/normal.go
+++ b/bot/normal/normal.go
@@ -37,6 +37,7 @@ type Node interface {
 	LiquidityProvisions(req *api.LiquidityProvisionsRequest) (response *api.LiquidityProvisionsResponse, err error)
 	MarketByID(req *api.MarketByIDRequest) (response *api.MarketByIDResponse, err error)
 	MarketDataByID(req *api.MarketDataByIDRequest) (response *api.MarketDataByIDResponse, err error)
+	Markets(req *api.MarketsRequest) (response *api.MarketsResponse, err error)
 	PartyAccounts(req *api.PartyAccountsRequest) (response *api.PartyAccountsResponse, err error)
 	PositionsByParty(req *api.PositionsByPartyRequest) (response *api.PositionsByPartyResponse, err error)
 	AssetByID(assetID string) (response *api.AssetByIDResponse, err error)

--- a/bot/normal/normal.go
+++ b/bot/normal/normal.go
@@ -141,23 +141,47 @@ func (b *Bot) Start() error {
 		"address": b.config.Location,
 	}).Debug("Connected to Vega gRPC node")
 
-	marketResponse, err := b.node.MarketByID(&api.MarketByIDRequest{MarketId: b.config.MarketID})
+	marketsResponse, err := b.node.Markets(&api.MarketsRequest{})
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("failed to get market %s", b.config.MarketID))
+		return fmt.Errorf("failed to get markets: %w", err)
 	}
-	if marketResponse.Market == nil {
-		return fmt.Errorf("No market that matchs our ID: %s", b.config.MarketID)
+	b.market = nil
+	for _, mkt := range marketsResponse.Markets {
+		instrument := mkt.TradableInstrument.GetInstrument()
+		if instrument != nil {
+			md := instrument.Metadata
+			base := ""
+			quote := ""
+			for _, tag := range md.Tags {
+				parts := strings.Split(tag, ":")
+				if len(parts) == 2 {
+					if parts[0] == "quote" {
+						quote = parts[1]
+					}
+					if parts[0] == "base" || parts[0] == "ticker" {
+						base = parts[1]
+					}
+				}
+			}
+			if base == b.config.InstrumentBase && quote == b.config.InstrumentQuote {
+				future := mkt.TradableInstrument.Instrument.GetFuture()
+				if future != nil {
+					b.settlementAssetID = future.SettlementAsset
+					b.market = mkt
+					break
+				}
+			}
+		}
 	}
-	b.market = marketResponse.Market
-	future := b.market.TradableInstrument.Instrument.GetFuture()
-	if future == nil {
-		return errors.New("market is not a Futures market")
+	if b.market == nil {
+		return fmt.Errorf("failed to find futures markets: base/ticker=%s, quote=%s", b.config.InstrumentBase, b.config.InstrumentQuote)
 	}
-	b.settlementAssetID = future.SettlementAsset
 	b.log.WithFields(log.Fields{
-		"marketID":          b.config.MarketID,
+		"id":                b.market.Id,
+		"base/ticker":       b.config.InstrumentBase,
+		"quote":             b.config.InstrumentQuote,
 		"settlementAssetID": b.settlementAssetID,
-	}).Debug("Fetched market info")
+	}).Info("Fetched market info")
 
 	// Use the settlementAssetID to lookup the settlement ethereum address
 	assetResponse, err := b.node.AssetByID(b.settlementAssetID)
@@ -420,8 +444,8 @@ func (b *Bot) sendOrder(
 func (b *Bot) checkInitialMargin() error {
 	// Turn the shapes into a set of orders scaled by commitment
 	obligation := b.strategy.CommitmentFraction * float64(b.balanceMargin+b.balanceBond+b.balanceGeneral)
-	buyOrders := b.calculateOrderSizes(b.config.MarketID, b.walletPubKeyHex, obligation, b.buyShape, b.marketData.MidPrice)
-	sellOrders := b.calculateOrderSizes(b.config.MarketID, b.walletPubKeyHex, obligation, b.sellShape, b.marketData.MidPrice)
+	buyOrders := b.calculateOrderSizes(b.market.Id, b.walletPubKeyHex, obligation, b.buyShape, b.marketData.MidPrice)
+	sellOrders := b.calculateOrderSizes(b.market.Id, b.walletPubKeyHex, obligation, b.sellShape, b.marketData.MidPrice)
 
 	buyRisk := float64(0.01)
 	sellRisk := float64(0.01)
@@ -646,49 +670,14 @@ func (b *Bot) calculateMarginCost(risk float64, markPrice uint64, orders []*prot
 	return totalMargin
 }
 
-func (b *Bot) getPriceParts() (base, quote string, err error) {
-	// If we have been passed in the values, use those
-	if len(b.config.InstrumentBase) > 0 &&
-		len(b.config.InstrumentQuote) > 0 {
-		return b.config.InstrumentBase, b.config.InstrumentQuote, nil
-	}
-
-	// Find out the underlying assets for this market
-	instrument := b.market.TradableInstrument.GetInstrument()
-	if instrument != nil {
-		md := instrument.Metadata
-		for _, tag := range md.Tags {
-			parts := strings.Split(tag, ":")
-			if len(parts) == 2 {
-				if parts[0] == "quote" {
-					quote = parts[1]
-				}
-				if parts[0] == "base" {
-					base = parts[1]
-				}
-			}
-		}
-	}
-	if len(quote) == 0 || len(base) == 0 {
-		return "", "", fmt.Errorf("Unable to work out price assets from market metadata")
-	}
-	return
-}
-
 func (b *Bot) runPriceSteering() {
 	var externalPrice, currentPrice uint64
 	var err error
 	var externalPriceResponse ppservice.PriceResponse
 
-	base, quote, err := b.getPriceParts()
-	if err != nil {
-		b.log.WithFields(log.Fields{"error": err.Error()}).
-			Fatal("Unable to build instrument for external price feed")
-	}
-
 	ppcfg := ppconfig.PriceConfig{
-		Base:   base,
-		Quote:  quote,
+		Base:   b.config.InstrumentBase,
+		Quote:  b.config.InstrumentQuote,
 		Wander: true,
 	}
 

--- a/bot/normal/streamingdata.go
+++ b/bot/normal/streamingdata.go
@@ -40,7 +40,7 @@ func (b *Bot) subscribeToEvents() error {
 		Type: []eventspb.BusEventType{
 			eventspb.BusEventType_BUS_EVENT_TYPE_MARKET_DATA,
 		},
-		MarketId: b.config.MarketID,
+		MarketId: b.market.Id,
 	}
 	stream2, err := b.node.ObserveEventBus()
 	if err != nil {
@@ -97,7 +97,7 @@ func (b *Bot) processEventBusData(stream api.TradingDataService_ObserveEventBusC
 
 func (b *Bot) subscribePositions() error {
 	req := &api.PositionsSubscribeRequest{
-		MarketId: b.config.MarketID,
+		MarketId: b.market.Id,
 		PartyId:  b.walletPubKeyHex,
 	}
 	stream, err := b.node.PositionsSubscribe(req)

--- a/config/config.go
+++ b/config/config.go
@@ -41,9 +41,6 @@ type BotConfig struct {
 	// CallTimeout is the per-call timeout (in milliseconds) for communicating with the Vega node gRPC endpoint.
 	CallTimeout int `yaml:"callTimeout"`
 
-	// MarketID is the Vega Market ID.
-	MarketID string `yaml:"marketID"`
-
 	// InstrumentBase is the base asset of the instrument
 	InstrumentBase string `yaml:"instrumentBase"`
 

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,7 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
+github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -74,8 +75,6 @@ github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4er
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
-github.com/golang/mock v1.5.0 h1:jlYHihg//f7RRwuPfptm04yp4s7O6Kw8EZiVYIGcH0g=
-github.com/golang/mock v1.5.0/go.mod h1:CWnOUgYIOo4TcNZ0wHX3YZCqsaM1I1Jvs6v3mP3KVu8=
 github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -205,6 +204,7 @@ go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/goleak v1.1.10 h1:z+mqJhf6ss6BSfSM671tgKyZBFPTTJM+HLxnhPC3wu0=
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.3.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=
@@ -213,8 +213,6 @@ go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9i
 go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee/go.mod h1:vJERXedbb3MVM5f9Ejo0C68/HhF8uaILCdgjnY+goOA=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.13.0/go.mod h1:zwrFLgMcdUuIBviXEYEH1YKNaOBnKXsx2IPda5bBwHM=
-go.uber.org/zap v1.17.0 h1:MTjgFu6ZLKvY6Pvaqk97GlxNBuMpV4Hy/3P6tRGlI2U=
-go.uber.org/zap v1.17.0/go.mod h1:MXVU+bhUf/A7Xi2HNOnopQOrmycQ5Ih87HtOu4q5SSo=
 go.uber.org/zap v1.18.1 h1:CSUJ2mjFszzEWt4CdKISEuChVIXGBn3lAPwkRGyVrc4=
 go.uber.org/zap v1.18.1/go.mod h1:xg/QME4nWcxGxrpdeYfq7UvYrLh66cuVKdrbD1XF/NI=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -245,12 +243,12 @@ golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvx
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
+golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 h1:VLliZ0d+/avPrXXH+OakdXhpJuEoBZuwh1m2j7U6Iug=
 golang.org/x/lint v0.0.0-20210508222113-6edffad5e616/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
-golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -347,7 +345,6 @@ google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQ
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
-google.golang.org/grpc v1.38.0 h1:/9BgsAsa5nWe26HqOlvlgJnqBuktYOLCgjCPqsa56W0=
 google.golang.org/grpc v1.38.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
 google.golang.org/grpc v1.39.0 h1:Klz8I9kdtkIN6EpHHUOMLCYhTn/2WAe5a0s1hcBkdTI=
 google.golang.org/grpc v1.39.0/go.mod h1:PImNr+rS9TWYb2O4/emRugxiyHZ5JyHW5F+RPnDzfrE=

--- a/node/grpcnode.go
+++ b/node/grpcnode.go
@@ -176,6 +176,29 @@ func (n *GRPCNode) MarketDataByID(req *api.MarketDataByIDRequest) (response *api
 	return
 }
 
+// Markets gets all Markets from the node
+func (n *GRPCNode) Markets(req *api.MarketsRequest) (response *api.MarketsResponse, err error) {
+	msg := "gRPC call failed: Markets: %w"
+	if n == nil {
+		err = fmt.Errorf(msg, e.ErrNil)
+		return
+	}
+
+	if n.conn.GetState() != connectivity.Ready {
+		err = fmt.Errorf(msg, e.ErrConnectionNotReady)
+		return
+	}
+
+	c := api.NewTradingDataServiceClient(n.conn)
+	ctx, cancel := context.WithTimeout(context.Background(), n.callTimeout)
+	defer cancel()
+	response, err = c.Markets(ctx, req)
+	if err != nil {
+		err = fmt.Errorf(msg, apigrpc.ErrorDetail(err))
+	}
+	return
+}
+
 // LiquidityProvisions gets the liquidity provisions for a given market and party.
 func (n *GRPCNode) LiquidityProvisions(req *api.LiquidityProvisionsRequest) (response *api.LiquidityProvisionsResponse, err error) {
 	msg := "gRPC call failed: LiquidityProvisions: %w"

--- a/service/mocks/bot_mock.go
+++ b/service/mocks/bot_mock.go
@@ -33,6 +33,20 @@ func (m *MockBot) EXPECT() *MockBotMockRecorder {
 	return m.recorder
 }
 
+// GetTraderDetails mocks base method.
+func (m *MockBot) GetTraderDetails() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTraderDetails")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetTraderDetails indicates an expected call of GetTraderDetails.
+func (mr *MockBotMockRecorder) GetTraderDetails() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTraderDetails", reflect.TypeOf((*MockBot)(nil).GetTraderDetails))
+}
+
 // Start mocks base method.
 func (m *MockBot) Start() error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
This PR removes the need for hard-coded market IDs, and instead looks up market IDs from base+quote info.

Closes #64