### PR TITLE
feat: add metadata filters for markets fetch

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -52,6 +52,9 @@ type BotConfig struct {
 
 	// StrategyDetails contains the parameters needed by the strategy algorithm.
 	StrategyDetails Strategy `yaml:"strategyDetails"`
+
+	// Additional metadata filters for the selecting markets
+	MetadataFilters []string `yaml:"metadataFilters"`
 }
 
 // Strategy describes parameters for the bot's strategy.


### PR DESCRIPTION
We have added the community market with the same base/quote pair. We cannot trade on new community markets at the moment.

Filter is defined here: https://github.com/vegaprotocol/k8s/blob/main/charts/apps/liqbot/devnet1/files/config.yaml#L738-L739

![image](https://github.com/vegaprotocol/liqbot/assets/1239637/1ceeee35-2826-4800-89d5-0e1ed0b3270b)
