### PR TITLE
feat: add market filtering for liqbot

### DIFF
--- a/bot/normal/datarequests.go
+++ b/bot/normal/datarequests.go
@@ -66,6 +66,7 @@ func (b *Bot) getAccount(typ vega.AccountType) (*num.Uint, error) {
 			PartyIds:     []string{b.walletPubKey},
 			AssetId:      b.settlementAssetID,
 			AccountTypes: []vega.AccountType{typ},
+			MarketIds:    []string{b.market.Id},
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
Fixed error:

```
 too many accounts for party: 2" node="api.n00.testnet.vega.rocks:3007" pubkey=e0e8c2feee3739b29adda77b6a1aeb274b1ee3dbb5fedf189da696c497653c39
time="2023-06-01T07:57:41.576191896Z" level=fatal msg="Failed to create service" error="failed to initialise bots: failed to initialise data: Failed to get margin account details: failed to get margin account balance: too many accounts for party: 2"
```